### PR TITLE
Fix build on federalist

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "postbuild": "npm run generate-routes",
     "dev": "vite",
     "generate-routes": "node -r esbuild-register bin/generate-routes.js",
-    "federalist": "npm run build -- --base=$BASEURL",
+    "federalist": "npm run build -- --base=${BASEURL:-/}",
     "prettier:fix": "npm run test:lint -- --fix",
     "serve": "vite preview",
     "test:lint": "eslint . --ext .js,.ts,.tsx",


### PR DESCRIPTION
- For our main deploy BASEURL is undefined, so default it to "/"
  with a lil bash trick


Error in Federalist builds:

```
2021-08-27 20:44:44 INFO [run-federalist-script] CACError: option `--base <path>` value is missing
```

I verified locally that this worked correctly